### PR TITLE
Update 404 redirect to keep no path segments

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -22,7 +22,7 @@
       // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
       // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
       // Otherwise, leave pathSegmentsToKeep as 0.
-      var pathSegmentsToKeep = 1;
+      var pathSegmentsToKeep = 0;
 
       var l = window.location;
       l.replace(


### PR DESCRIPTION
Changed the 404.html redirect logic to set pathSegmentsToKeep to 0 instead of 1, so that all path segments are removed from the redirected URL. This ensures users are redirected to the root with query parameters preserved.