### PR TITLE
Preserve first path segment in 404 redirect

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -22,7 +22,7 @@
       // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
       // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
       // Otherwise, leave pathSegmentsToKeep as 0.
-      var pathSegmentsToKeep = 0;
+      var pathSegmentsToKeep = 1;
 
       var l = window.location;
       l.replace(


### PR DESCRIPTION
Changed pathSegmentsToKeep from 0 to 1 in 404.html to retain the first path segment during redirect. This helps maintain more context in the redirected URL.