### PR TITLE
Set BrowserRouter basename to /sanX

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,9 +4,8 @@ import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import { App } from 'App';
 
-
 ReactDOM.createRoot(document.getElementById('root')).render(
- <BrowserRouter basename='' >
+  <BrowserRouter basename="/sanX">
     <App />
-</BrowserRouter>
+  </BrowserRouter>
 );


### PR DESCRIPTION
Updated the BrowserRouter basename from an empty string to '/sanX' in index.js to ensure correct routing under the /sanX path.