### PR TITLE
Adjust member form image width to 70%

### DIFF
--- a/src/Page/MemberCard.styled.jsx
+++ b/src/Page/MemberCard.styled.jsx
@@ -36,7 +36,7 @@ export const MemberForm = styled.form`
 
   & img {
     display: block;
-    width: 150px;
+    width: 70%;
     height: auto;
     object-fit: cover;
     align-self: center;


### PR DESCRIPTION
Updated the styled component for MemberForm to set the image width to 70% instead of a fixed 150px, allowing for more responsive design.