### PR TITLE
Adjust image object position in MemberDiv

### DIFF
--- a/src/Page/Membership.styled.jsx
+++ b/src/Page/Membership.styled.jsx
@@ -17,7 +17,7 @@ export const MemberDiv = styled.div`
     width: 100%;
     height: 200px;
     object-fit: cover;
-    object-position: 50% 60%;
+    object-position: 50% 70%;
   }
 
   & .payLink {


### PR DESCRIPTION
Changed the object-position of images in MemberDiv from 50% 60% to 50% 70% to improve visual alignment.